### PR TITLE
Update to android/build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,5 +16,5 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
Related to issue #105
WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html